### PR TITLE
fix: detect project plugins from settings files instead of projectPath

### DIFF
--- a/internal/claude/CLAUDE.md
+++ b/internal/claude/CLAUDE.md
@@ -1,10 +1,10 @@
 # Claude CLI Client
 
-Last verified: 2026-01-24
+Last verified: 2026-01-26
 
 ## Purpose
 
-Provides a typed Go interface to the Claude Code CLI and plugin manifest reading, isolating shell-out complexity from the TUI layer.
+Provides a typed Go interface to the Claude Code CLI, plugin manifest reading, and project settings, isolating shell-out complexity from the TUI layer.
 
 ## Contracts
 
@@ -12,6 +12,8 @@ Provides a typed Go interface to the Claude Code CLI and plugin manifest reading
 - **Exposes**: `ReadPluginManifest(installPath)` - reads plugin.json for metadata
 - **Exposes**: `ScanPluginComponents(installPath)` - discovers skills, agents, commands, hooks, MCPs
 - **Exposes**: `ResolveMarketplaceSourcePath(marketplace, source)` - resolves local marketplace paths
+- **Exposes**: `GetProjectEnabledPlugins(workingDir)` - reads project settings files to get enabled plugins
+- **Exposes**: `ReadProjectSettings(settingsPath)` - reads a single settings file
 - **Guarantees**: Returns structured `PluginList` with typed `InstalledPlugin`/`AvailablePlugin`. Errors include stderr output.
 - **Expects**: `claude` binary in PATH (or custom path via `NewClientWithPath`)
 
@@ -27,6 +29,8 @@ Provides a typed Go interface to the Claude Code CLI and plugin manifest reading
 - Shell out vs. library: Claude Code has no Go SDK; CLI is the only integration point
 - JSON parsing: Uses `claude plugin list --json --available` for structured data
 - Manifest parsing: Handles flexible author field (string or object format)
+- Install/Uninstall use enable/disable: `InstallPlugin` calls `claude plugin enable`, `UninstallPlugin` calls `claude plugin disable` (semantically correct for project-scoped operations)
+- Settings as source of truth: Project settings files (`.claude/settings.json`, `.claude/settings.local.json`) determine which plugins are enabled for a project, not the CLI's `projectPath` field
 
 ## Invariants
 
@@ -39,4 +43,4 @@ Provides a typed Go interface to the Claude Code CLI and plugin manifest reading
 
 - `types.go` - Scope enum, InstalledPlugin, AvailablePlugin, PluginList
 - `client.go` - Client interface and realClient implementation
-- `manifest.go` - PluginManifest, PluginComponents, manifest reading and component scanning
+- `manifest.go` - PluginManifest, PluginComponents, ProjectSettings, manifest/settings reading and component scanning

--- a/internal/claude/client.go
+++ b/internal/claude/client.go
@@ -67,7 +67,7 @@ func (c *realClient) ListPlugins(includeAvailable bool) (*PluginList, error) {
 
 // InstallPlugin implements Client.InstallPlugin.
 func (c *realClient) InstallPlugin(pluginID string, scope Scope) error {
-	args := []string{"plugin", "install"}
+	args := []string{"plugin", "enable"}
 	if scope != ScopeNone {
 		args = append(args, "--scope", string(scope))
 	}
@@ -87,7 +87,7 @@ func (c *realClient) InstallPlugin(pluginID string, scope Scope) error {
 
 // UninstallPlugin implements Client.UninstallPlugin.
 func (c *realClient) UninstallPlugin(pluginID string, scope Scope) error {
-	args := []string{"plugin", "uninstall"}
+	args := []string{"plugin", "disable"}
 	if scope != ScopeNone {
 		args = append(args, "--scope", string(scope))
 	}

--- a/internal/tui/CLAUDE.md
+++ b/internal/tui/CLAUDE.md
@@ -1,6 +1,6 @@
 # TUI Package
 
-Last verified: 2026-01-24
+Last verified: 2026-01-26
 
 ## Purpose
 
@@ -14,7 +14,7 @@ Implements the two-pane plugin manager interface using Bubble Tea's Elm Architec
 
 ## Dependencies
 
-- **Uses**: internal/claude (Client interface), Bubble Tea, Lip Gloss
+- **Uses**: internal/claude (Client interface, GetProjectEnabledPlugins), Bubble Tea, Lip Gloss
 - **Used by**: cmd/cpm (creates Model, runs tea.Program)
 - **Boundary**: No direct CLI calls; all plugin operations go through Client
 
@@ -25,6 +25,7 @@ Implements the two-pane plugin manager interface using Bubble Tea's Elm Architec
 - Operation type enum: `OpInstall`, `OpUninstall`, `OpEnable`, `OpDisable` define operation types
 - Mode enum: `ModeMain`, `ModeProgress`, `ModeSummary` control view rendering
 - Group headers: Non-selectable `PluginState` entries with `IsGroupHeader=true`
+- Settings-based filtering: Project plugins determined by reading `.claude/settings.json` and `.claude/settings.local.json`, not CLI's `projectPath` field
 
 ## Invariants
 


### PR DESCRIPTION
## Summary

- Fix plugin detection to use project settings files (`.claude/settings.json`, `.claude/settings.local.json`) as the source of truth for which plugins are enabled
- The CLI's `projectPath` field was unreliable - it shows where a plugin was originally installed, not where it's currently enabled
- Change `InstallPlugin`/`UninstallPlugin` to use `enable`/`disable` commands (semantically correct for project-scoped operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)