### PR TITLE
fix: update goreleaser config for renamed repository

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,7 +52,7 @@ homebrew_casks:
       owner: open-cli-collective
       name: homebrew-tap
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
-    homepage: https://github.com/open-cli-collective/claude-plugin-manager
+    homepage: https://github.com/open-cli-collective/cpm
     description: "TUI for managing Claude Code plugins"
     binary: cpm
     hooks:
@@ -88,6 +88,6 @@ changelog:
 release:
   github:
     owner: open-cli-collective
-    name: claude-plugin-manager
+    name: cpm
   draft: false
   prerelease: auto


### PR DESCRIPTION
## Summary

- Update `homepage` URL from `claude-plugin-manager` to `cpm`
- Update `release.github.name` from `claude-plugin-manager` to `cpm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)